### PR TITLE
Change error to responseURL

### DIFF
--- a/fs.js
+++ b/fs.js
@@ -6,7 +6,7 @@ exports.readFileSync = function(address) {
     if (xhr.readyState == 4) {
       var status = xhr.status;
       if ((status > 399 && status < 600) || status == 400) {
-        throw 'File read error on ' + address;
+        throw 'File read error on ' + xhr.responseURL;
       }
       else
         output = xhr.responseText;


### PR DESCRIPTION
When calling readFileSync with a relative path (i.e. /jspm/jspm_packages/npm/svgo@0.6.1/lib/svgo/../../.svgo.yml) it's a little weird to see the error message reference a relative URL. It gives the impression that the URL wasn't properly decoded.

Instead, consider using responseURL which accurately represents what was requested.
